### PR TITLE
Various fixes - fix #129, #134, #135

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -14,6 +14,7 @@ Knet 0.9
 LIBSVM 0.1
 Literate 0.2
 MLBase 0.7
+MLDatasets
 Metalhead 0.1
 NBInclude 1.2
 NumericalIntegration 0.0.3

--- a/src/toplevel/io/saveload.jl
+++ b/src/toplevel/io/saveload.jl
@@ -10,12 +10,13 @@ import ProgressMeter
 """
 function save_model(filename::AbstractString,fittable_object_to_save::Fittable)
     if filename_extension(filename) == ".jld2"
-        result = save_model_jld2(filename,fittable_object_to_save)
+        save_result = save_model_jld2(filename,fittable_object_to_save)
     elseif filename_extension(filename) == ".bson"
-        result = save_model_bson(filename,fittable_object_to_save)
+        save_result = save_model_bson(filename,fittable_object_to_save)
     else
         error("extension must be one of: .jld2, .bson")
     end
+    return filename
 end
 
 function save_model_jld2(filename::AbstractString,fittable_object_to_save::Fittable)
@@ -37,7 +38,7 @@ function save_model_jld2(filename::AbstractString,fittable_object_to_save::Fitta
     # save the .jld2 file
     FileIO.save(filename, dict_of_objects_to_save)
     info(string("Saved model to file \"", filename, "\""))
-    return nothing
+    return filename
 end
 
 function save_model_bson(filename::AbstractString,fittable_object_to_save::Fittable)
@@ -59,17 +60,18 @@ function save_model_bson(filename::AbstractString,fittable_object_to_save::Fitta
     # save the .bson file
     BSON.bson(filename, dict_of_objects_to_save)
     info(string("Saved model to file \"", filename, "\""))
+    return filename
 end
 
 """
 """
 function load_model(filename::AbstractString)
     if filename_extension(filename) == ".jld2"
-        result = load_model_jld2(filename)
-        return result
+        load_result = load_model_jld2(filename)
+        return load_result
     elseif filename_extension(filename) == ".bson"
-        result = load_model_bson(filename)
-        return result
+        load_result = load_model_bson(filename)
+        return load_result
     else
         error("extension must be one of: .jld2, .bson")
     end
@@ -104,4 +106,5 @@ function load_model_bson(filename::AbstractString)
     dict_of_loaded_objects = BSON.load(filename)
     loaded_fittable_object = dict_of_loaded_objects[:bson_saved_model]
     info(string("Loaded model from file \"", filename, "\""))
+    return loaded_fittable_object
 end

--- a/src/toplevel/utils/file_exists.jl
+++ b/src/toplevel/utils/file_exists.jl
@@ -1,8 +1,12 @@
+"""
+"""
 function filename_extension(filename::AbstractString)
     result = lowercase(strip(splitext(filename)[2]))
     return result
 end
 
+"""
+"""
 function something_exists_at_path(path::AbstractString)
     if ispath(path)
         return true

--- a/src/toplevel/utils/tikzpictures.jl
+++ b/src/toplevel/utils/tikzpictures.jl
@@ -3,24 +3,19 @@ import TikzPictures
 """
 """
 function save_plot(filename::AbstractString, tp::TikzPictures.TikzPicture)
-    extension = lowercase(strip(splitext(filename)[2]))
+    extension = filename_extension(filename)
     if extension == ".pdf"
-        return save_plot_pdf(filename, tp)
+        save_result = save_plot_pdf(filename, tp)
     elseif extension == ".tex"
-        return save_plot_tex(filename, tp)
+        save_result = save_plot_tex(filename, tp)
     elseif extension == ".tikz"
-        return save_plot_tikz(filename, tp)
+        save_result = save_plot_tikz(filename, tp)
     elseif extension == ".svg"
-        return save_plot_svg(filename, tp)
+        save_result = save_plot_svg(filename, tp)
     else
-        error(
-            string(
-                "I don't know how to save a picture in file format \"",
-                extension,
-                "\".",
-                )
-            )
+        error("File extension must be one of: .pdf, .tex, .tikz, .svg")
     end
+    return filename
 end
 
 """
@@ -28,8 +23,8 @@ end
 function save_plot_pdf(filename::AbstractString, tp::TikzPictures.TikzPicture)
     parent_directory = Base.Filesystem.dirname(filename)
     Base.Filesystem.mkpath(parent_directory)
-    result = TikzPictures.save(TikzPictures.PDF(filename), tp)
-    return result
+    save_result = TikzPictures.save(TikzPictures.PDF(filename), tp)
+    return filename
 end
 
 """
@@ -37,8 +32,8 @@ end
 function save_plot_tex(filename::AbstractString, tp::TikzPictures.TikzPicture)
     parent_directory = Base.Filesystem.dirname(filename)
     Base.Filesystem.mkpath(parent_directory)
-    result = TikzPictures.save(TikzPictures.TEX(filename), tp)
-    return result
+    save_result = TikzPictures.save(TikzPictures.TEX(filename), tp)
+    return filename
 end
 
 """
@@ -46,8 +41,8 @@ end
 function save_plot_tikz(filename::AbstractString, tp::TikzPictures.TikzPicture)
     parent_directory = Base.Filesystem.dirname(filename)
     Base.Filesystem.mkpath(parent_directory)
-    result = TikzPictures.save(TikzPictures.TIKZ(filename), tp)
-    return result
+    save_result = TikzPictures.save(TikzPictures.TIKZ(filename), tp)
+    return filename
 end
 
 """
@@ -55,22 +50,22 @@ end
 function save_plot_svg(filename::AbstractString, tp::TikzPictures.TikzPicture)
     parent_directory = Base.Filesystem.dirname(filename)
     Base.Filesystem.mkpath(parent_directory)
-    result = TikzPictures.save(TikzPictures.SVG(filename), tp)
-    return result
+    save_result = TikzPictures.save(TikzPictures.SVG(filename), tp)
+    return filename
 end
 
 """
 """
 function open_plot(tp::TikzPictures.TikzPicture)
-    tempsvgfilename = string(tempname(), ".svg")
-    result = open_plot(tempsvgfilename, tp)
-    return result
+    temp_svg_filename = string(tempname(), ".svg")
+    save_result = open_plot(temp_svg_filename, tp)
+    return temp_svg_filename
 end
 
 """
 """
 function open_plot(filename::AbstractString, tp::TikzPictures.TikzPicture)
     saveresult = save_plot(filename, tp)
-    openresult = open_browser_window(filename)
-    return openresult
+    open_result = open_browser_window(filename)
+    return filename
 end


### PR DESCRIPTION
If in an IJulia session, open plots in the notebook instead of calling xdg-open - fix #129 

The return value of save_model() is the filename to which the model was saved - fix #134 

The return value of save_plot, save_plot_svg (and similar functions), and open_browser_window is the filename of the file that was saved/and opened - fix #135 