### PR TITLE
Specify acceptable range for DataFrames version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,6 +7,7 @@ CSVFiles
 CUDAapi
 ClassImbalance
 Combinatorics
+DataFrames 0.11 0.12
 DecisionTree
 Documenter
 Flux


### PR DESCRIPTION
We are doing this because `DataFrames.readtable` will be removed in a future version of DataFrames. However, there are some CSV's for which `CSV.read` and `CSVFiles.load` don't work (and thus we need to use `DataFrames.readtable`).